### PR TITLE
Support caching PDFs and only run caching plugin on fresh pulled pages.

### DIFF
--- a/.changeset/tricky-cougars-design.md
+++ b/.changeset/tricky-cougars-design.md
@@ -1,0 +1,7 @@
+---
+"@agency-kit/notion-cms": minor
+---
+
+Fix: image cache plugin will now only run when a page needs updated (not using cache).
+
+New: cache PDFs using the image plugin. Long term this will likely be a unified plugin for fetching/caching all AWS S3 hosted Notion assets.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced caching for PDFs in addition to images, enhancing the performance for pages with PDF content.
- **Bug Fixes**
	- Improved the image cache plugin to activate only when page updates are necessary, optimizing resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->